### PR TITLE
Fix Issue #3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ python-dateutil==2.7.2
 pytz==2018.4
 requests==2.18.4
 urllib3==1.22
-Werkzeug==0.14.1
+Werkzeug==0.15.4


### PR DESCRIPTION
The previously mentioned version of Werkzeug yield the following error :
```
ModuleNotFoundError: No module named 'werkzeug.wrappers.json'; 'werkzeug.wrappers' is not a package
```
Changing it to 0.15.4 fixes the issue.
Source: https://stackoverflow.com/questions/56933523/apache-airflow-airflow-initdb-throws-modulenotfounderror-no-module-named-wer